### PR TITLE
Lanecover

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/BGAnimations/ScreenGameplay overlay/default.lua
@@ -1,5 +1,6 @@
 t = Def.ActorFrame{}
 t[#t+1] = LoadActor("scoretracking")
+t[#t+1] = LoadActor("lanecover")
 t[#t+1] = LoadActor("judgecount")
 t[#t+1] = LoadActor("pacemaker")
 t[#t+1] = LoadActor("ghostscore")

--- a/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/BGAnimations/ScreenGameplay overlay/default.lua
@@ -1,9 +1,10 @@
 t = Def.ActorFrame{}
 t[#t+1] = LoadActor("scoretracking")
+t[#t+1] = LoadActor("ghostscore")
 t[#t+1] = LoadActor("lanecover")
 t[#t+1] = LoadActor("judgecount")
 t[#t+1] = LoadActor("pacemaker")
-t[#t+1] = LoadActor("ghostscore")
+
 t[#t+1] = LoadActor("progressbar")
 t[#t+1] = LoadActor("errorbar")
 t[#t+1] = LoadActor("avatar")

--- a/BGAnimations/ScreenGameplay overlay/lanecover.lua
+++ b/BGAnimations/ScreenGameplay overlay/lanecover.lua
@@ -52,6 +52,7 @@ local t = Def.ActorFrame{
 				moveUpP2 = false
 			end
 		end;
+		self:playcommand("SavePrefs")
 	end;
 	SavePrefsCommand=function(self)
 		if enabledP1 then
@@ -65,8 +66,6 @@ local t = Def.ActorFrame{
 			playerConfig:save(pn_to_profile_slot(PLAYER_2))
 		end;
 	end;
-	OffCommand=cmd(playcommand,"SavePrefs");
-	CancelCommand=cmd(playcommand,"SavePrefs");
 }
 
 if enabledP1 then
@@ -89,12 +88,17 @@ if enabledP1 then
 		InitCommand=cmd(x,P1X;settext,0;valign,1;zoom,0.5;);
 		BeginCommand=function(self)
 			if isReverseP1 then
-				self:y(SCREEN_TOP)
+				self:y(heightP1-5)
 				self:valign(1)
 			else
-				self:y(SCREEN_BOTTOM)
+				self:y(SCREEN_BOTTOM-heightP1+5)
 				self:valign(0)
 			end;
+			self:finishtweening()
+			self:diffusealpha(1)
+			self:sleep(0.25)
+			self:smooth(0.75)
+			self:diffusealpha(0)
 		end;
 	};
 end;
@@ -119,12 +123,17 @@ if enabledP2 then
 		InitCommand=cmd(x,P2X;settext,0;valign,1;zoom,0.5;);
 		BeginCommand=function(self)
 			if isReverseP2 then
-				self:y(SCREEN_TOP-5)
+				self:y(heightP2-5)
 				self:valign(1)
 			else
-				self:y(SCREEN_BOTTOM+5)
+				self:y(SCREEN_BOTTOM-heightP2+5)
 				self:valign(0)
 			end;
+			self:finishtweening()
+			self:diffusealpha(1)
+			self:sleep(0.25)
+			self:smooth(0.75)
+			self:diffusealpha(0)
 		end;
 	};
 end;

--- a/BGAnimations/ScreenGameplay overlay/lanecover.lua
+++ b/BGAnimations/ScreenGameplay overlay/lanecover.lua
@@ -1,0 +1,59 @@
+local moveUp = false
+local moveDown = false
+local t = Def.ActorFrame{
+	CodeMessageCommand = function(self, params)
+		moveDown = false
+		moveUp = false
+		if params.Name == "LaneUp" then
+			moveUp = true
+		elseif params.Name == "LaneDown" then
+			moveDown = true
+		else
+			moveDown = false
+			moveUp = false
+		end
+	end;
+}
+
+local laneType = 0 --0  = off, 1 = notefield only, 2 = full width
+local isReverse = 0 -- will be at top if reverse, bottom if not.
+
+local cols = GAMESTATE:GetCurrentStyle():ColumnsPerPlayer()
+
+local isCentered = ((cols >= 6) or PREFSMAN:GetPreference("Center1Player")) -- load from prefs later
+local width = 64*6+8
+local height = 0
+
+t[#t+1] = Def.Quad{
+	Name="Cover";
+	InitCommand=cmd(xy,SCREEN_CENTER_X,SCREEN_TOP;zoomto,width,height;valign,0;diffuse,color("#000000"));
+}
+
+t[#t+1] = LoadFont("Common Normal")..{
+	Name="CoverText";
+	InitCommand=cmd(xy,SCREEN_CENTER_X,SCREEN_TOP;settext,0;valign,1;)
+
+}
+
+
+local function Update(self)
+	t.InitCommand=cmd(SetUpdateFunction,Update);
+	if moveDown then
+		height = height+1
+		self:GetChild("Cover"):zoomy(height)
+		self:GetChild("CoverText"):y(height)
+		self:GetChild("CoverText"):settext(height)
+		--moveDown = false
+	end;
+	if moveUp then
+		height = height-1
+		self:GetChild("Cover"):zoomy(height)
+		self:GetChild("CoverText"):y(height)
+		self:GetChild("CoverText"):settext(height)
+		--moveUp = false
+	end;
+end; 
+t.InitCommand=cmd(SetUpdateFunction,Update);
+
+
+return t

--- a/BGAnimations/ScreenGameplay overlay/lanecover.lua
+++ b/BGAnimations/ScreenGameplay overlay/lanecover.lua
@@ -1,56 +1,185 @@
-local moveUp = false
-local moveDown = false
-local t = Def.ActorFrame{
-	CodeMessageCommand = function(self, params)
-		moveDown = false
-		moveUp = false
-		if params.Name == "LaneUp" then
-			moveUp = true
-		elseif params.Name == "LaneDown" then
-			moveDown = true
-		else
-			moveDown = false
-			moveUp = false
-		end
-	end;
-}
-
-local laneType = 0 --0  = off, 1 = notefield only, 2 = full width
-local isReverse = 0 -- will be at top if reverse, bottom if not.
+local moveUpP1 = false
+local moveDownP1 = false
+local moveUpP2 = false
+local moveDownP2 = false
 
 local cols = GAMESTATE:GetCurrentStyle():ColumnsPerPlayer()
 
-local isCentered = ((cols >= 6) or PREFSMAN:GetPreference("Center1Player")) -- load from prefs later
-local width = 64*6+8
-local height = 0
+local isCentered = ((cols >= 6) or PREFSMAN:GetPreference("Center1Player")) and GAMESTATE:GetNumPlayersEnabled() == 1-- load from prefs later
+local width = 64*cols
+local padding = 8
+local styleType = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
-t[#t+1] = Def.Quad{
-	Name="Cover";
-	InitCommand=cmd(xy,SCREEN_CENTER_X,SCREEN_TOP;zoomto,width,height;valign,0;diffuse,color("#000000"));
+local enabledP1 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCover and GAMESTATE:IsPlayerEnabled(PLAYER_1)
+local isReverseP1 = GAMESTATE:GetPlayerState(PLAYER_1):GetCurrentPlayerOptions():UsingReverse()
+
+local enabledP2 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCover  and GAMESTATE:IsPlayerEnabled(PLAYER_2)
+local isReverseP2 = GAMESTATE:GetPlayerState(PLAYER_2):GetCurrentPlayerOptions():UsingReverse()
+
+local heightP1 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCoverHeight
+local heightP2 = playerConfig:get_data(pn_to_profile_slot(PLAYER_2)).LaneCoverHeight
+
+local P1X = SCREEN_CENTER_X
+local P2X = SCREEN_CENTER_X
+if not isCentered then
+	P1X = THEME:GetMetric("ScreenGameplay",string.format("PlayerP1%sX",styleType))
+	P2X = THEME:GetMetric("ScreenGameplay",string.format("PlayerP2%sX",styleType))
+end;
+
+local t = Def.ActorFrame{
+	CodeMessageCommand = function(self, params)
+		moveDownP1 = false
+		moveUpP1 = false
+		moveDownP2 = false
+		moveUpP2 = false
+		if params.PlayerNumber == PLAYER_1 then
+			if params.Name == "LaneUp" then
+				moveUpP1 = true
+			elseif params.Name == "LaneDown" then
+				moveDownP1 = true
+			else
+				moveDownP1 = false
+				moveUpP1 = false
+			end
+		end;
+		if params.PlayerNumber == PLAYER_2 then
+			if params.Name == "LaneUp" then
+				moveUpP2 = true
+			elseif params.Name == "LaneDown" then
+				moveDownP2 = true
+			else
+				moveDownP2 = false
+				moveUpP2 = false
+			end
+		end;
+	end;
+	SavePrefsCommand=function(self)
+		if enabledP1 then
+			playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCoverHeight = heightP1
+			playerConfig:set_dirty(pn_to_profile_slot(PLAYER_1))
+			playerConfig:save(pn_to_profile_slot(PLAYER_1))
+		end;
+		if enabledP2 then
+			playerConfig:get_data(pn_to_profile_slot(PLAYER_2)).LaneCoverHeight = heightP2
+			playerConfig:set_dirty(pn_to_profile_slot(PLAYER_2))
+			playerConfig:save(pn_to_profile_slot(PLAYER_2))
+		end;
+	end;
+	OffCommand=cmd(playcommand,"SavePrefs");
+	CancelCommand=cmd(playcommand,"SavePrefs");
 }
 
-t[#t+1] = LoadFont("Common Normal")..{
-	Name="CoverText";
-	InitCommand=cmd(xy,SCREEN_CENTER_X,SCREEN_TOP;settext,0;valign,1;)
+if enabledP1 then
+	t[#t+1] = Def.Quad{
+		Name="CoverP1";
+		InitCommand=cmd(xy,P1X,SCREEN_TOP;zoomto,width+padding,heightP1;valign,0;diffuse,color("#000000"));
+		BeginCommand=function(self)
+			if isReverseP1 then
+				self:y(SCREEN_TOP)
+				self:valign(0)
+			else
+				self:y(SCREEN_BOTTOM)
+				self:valign(1)
+			end;
+		end;
+	};
 
-}
+	t[#t+1] = LoadFont("Common Normal")..{
+		Name="CoverTextP1";
+		InitCommand=cmd(x,P1X;settext,0;valign,1;zoom,0.5;);
+		BeginCommand=function(self)
+			if isReverseP1 then
+				self:y(SCREEN_TOP)
+				self:valign(1)
+			else
+				self:y(SCREEN_BOTTOM)
+				self:valign(0)
+			end;
+		end;
+	};
+end;
 
+if enabledP2 then
+	t[#t+1] = Def.Quad{
+		Name="CoverP2";
+		InitCommand=cmd(xy,P2X,SCREEN_TOP;zoomto,width+padding,heightP2;valign,0;diffuse,color("#000000"));
+		BeginCommand=function(self)
+			if isReverseP2 then
+				self:y(SCREEN_TOP)
+				self:valign(0)
+			else
+				self:y(SCREEN_BOTTOM)
+				self:valign(1)
+			end;
+		end;
+	};
+
+	t[#t+1] = LoadFont("Common Normal")..{
+		Name="CoverTextP2";
+		InitCommand=cmd(x,P2X;settext,0;valign,1;zoom,0.5;);
+		BeginCommand=function(self)
+			if isReverseP2 then
+				self:y(SCREEN_TOP-5)
+				self:valign(1)
+			else
+				self:y(SCREEN_BOTTOM+5)
+				self:valign(0)
+			end;
+		end;
+	};
+end;
 
 local function Update(self)
 	t.InitCommand=cmd(SetUpdateFunction,Update);
-	if moveDown then
-		height = height+1
-		self:GetChild("Cover"):zoomy(height)
-		self:GetChild("CoverText"):y(height)
-		self:GetChild("CoverText"):settext(height)
-		--moveDown = false
+	if enabledP1 then
+		if moveDownP1 then
+			heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1+1))
+		end;
+		if moveUpP1 then
+			heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1-1))
+
+		end;
+
+		self:GetChild("CoverP1"):zoomy(heightP1)
+		self:GetChild("CoverTextP1"):settext(heightP1)
+		if isReverseP1 then
+			self:GetChild("CoverTextP1"):y(heightP1-5)
+		else
+			self:GetChild("CoverTextP1"):y(SCREEN_BOTTOM-heightP1+5)
+		end;
+
+		if moveDownP1 or moveUpP1 then
+			self:GetChild("CoverTextP1"):finishtweening()
+			self:GetChild("CoverTextP1"):diffusealpha(1)
+			self:GetChild("CoverTextP1"):sleep(0.25)
+			self:GetChild("CoverTextP1"):smooth(0.75)
+			self:GetChild("CoverTextP1"):diffusealpha(0)
+		end;
+
 	end;
-	if moveUp then
-		height = height-1
-		self:GetChild("Cover"):zoomy(height)
-		self:GetChild("CoverText"):y(height)
-		self:GetChild("CoverText"):settext(height)
-		--moveUp = false
+
+	if enabledP2 then
+		if moveDownP2 then
+			heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2+1))
+		end;
+		if moveUpP2 then
+			heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2-1))
+		end;
+		self:GetChild("CoverP2"):zoomy(heightP2)
+		self:GetChild("CoverTextP2"):settext(heightP2)
+		if isReverseP2 then
+			self:GetChild("CoverTextP2"):y(heightP2-5)
+		else
+			self:GetChild("CoverTextP2"):y(SCREEN_BOTTOM-heightP2+5)
+		end;
+
+		if moveDownP2 or moveUpP2 then
+			self:GetChild("CoverTextP1"):finishtweening()
+			self:GetChild("CoverTextP1"):diffusealpha(1)
+			self:GetChild("CoverTextP1"):sleep(0.25)
+			self:GetChild("CoverTextP1"):smooth(0.75)
+			self:GetChild("CoverTextP1"):diffusealpha(0)
+		end;
 	end;
 end; 
 t.InitCommand=cmd(SetUpdateFunction,Update);

--- a/BGAnimations/ScreenGameplay overlay/lanecover.lua
+++ b/BGAnimations/ScreenGameplay overlay/lanecover.lua
@@ -144,11 +144,18 @@ local function Update(self)
 	t.InitCommand=cmd(SetUpdateFunction,Update);
 	if enabledP1 then
 		if moveDownP1 then
-			heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1+1))
+			if isReverseP1 then
+				heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1+1))
+			else
+				heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1-1))
+			end;
 		end;
 		if moveUpP1 then
-			heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1-1))
-
+			if isReverseP1 then
+				heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1-1))
+			else
+				heightP1 = math.min(SCREEN_BOTTOM,math.max(0,heightP1+1))
+			end;
 		end;
 
 		self:GetChild("CoverP1"):zoomy(heightP1)
@@ -171,10 +178,18 @@ local function Update(self)
 
 	if enabledP2 then
 		if moveDownP2 then
-			heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2+1))
+			if isReverseP2 then
+				heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2+1))
+			else
+				heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2-1))
+			end;
 		end;
 		if moveUpP2 then
-			heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2-1))
+			if isReverseP2 then
+				heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2-1))
+			else
+				heightP2 = math.min(SCREEN_BOTTOM,math.max(0,heightP2+1))
+			end;
 		end;
 		self:GetChild("CoverP2"):zoomy(heightP2)
 		self:GetChild("CoverTextP2"):settext(heightP2)

--- a/BGAnimations/ScreenGameplay overlay/lanecover.lua
+++ b/BGAnimations/ScreenGameplay overlay/lanecover.lua
@@ -3,6 +3,8 @@ local moveDownP1 = false
 local moveUpP2 = false
 local moveDownP2 = false
 
+local laneColor = color("#333333")
+
 local cols = GAMESTATE:GetCurrentStyle():ColumnsPerPlayer()
 
 local isCentered = ((cols >= 6) or PREFSMAN:GetPreference("Center1Player")) and GAMESTATE:GetNumPlayersEnabled() == 1-- load from prefs later
@@ -13,7 +15,7 @@ local styleType = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local enabledP1 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCover and GAMESTATE:IsPlayerEnabled(PLAYER_1)
 local isReverseP1 = GAMESTATE:GetPlayerState(PLAYER_1):GetCurrentPlayerOptions():UsingReverse()
 
-local enabledP2 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCover  and GAMESTATE:IsPlayerEnabled(PLAYER_2)
+local enabledP2 = playerConfig:get_data(pn_to_profile_slot(PLAYER_2)).LaneCover  and GAMESTATE:IsPlayerEnabled(PLAYER_2)
 local isReverseP2 = GAMESTATE:GetPlayerState(PLAYER_2):GetCurrentPlayerOptions():UsingReverse()
 
 local heightP1 = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).LaneCoverHeight
@@ -71,7 +73,7 @@ local t = Def.ActorFrame{
 if enabledP1 then
 	t[#t+1] = Def.Quad{
 		Name="CoverP1";
-		InitCommand=cmd(xy,P1X,SCREEN_TOP;zoomto,width+padding,heightP1;valign,0;diffuse,color("#000000"));
+		InitCommand=cmd(xy,P1X,SCREEN_TOP;zoomto,width+padding,heightP1;valign,0;diffuse,laneColor);
 		BeginCommand=function(self)
 			if isReverseP1 then
 				self:y(SCREEN_TOP)
@@ -106,7 +108,7 @@ end;
 if enabledP2 then
 	t[#t+1] = Def.Quad{
 		Name="CoverP2";
-		InitCommand=cmd(xy,P2X,SCREEN_TOP;zoomto,width+padding,heightP2;valign,0;diffuse,color("#000000"));
+		InitCommand=cmd(xy,P2X,SCREEN_TOP;zoomto,width+padding,heightP2;valign,0;diffuse,laneColor);
 		BeginCommand=function(self)
 			if isReverseP2 then
 				self:y(SCREEN_TOP)
@@ -183,11 +185,11 @@ local function Update(self)
 		end;
 
 		if moveDownP2 or moveUpP2 then
-			self:GetChild("CoverTextP1"):finishtweening()
-			self:GetChild("CoverTextP1"):diffusealpha(1)
-			self:GetChild("CoverTextP1"):sleep(0.25)
-			self:GetChild("CoverTextP1"):smooth(0.75)
-			self:GetChild("CoverTextP1"):diffusealpha(0)
+			self:GetChild("CoverTextP2"):finishtweening()
+			self:GetChild("CoverTextP2"):diffusealpha(1)
+			self:GetChild("CoverTextP2"):sleep(0.25)
+			self:GetChild("CoverTextP2"):smooth(0.75)
+			self:GetChild("CoverTextP2"):diffusealpha(0)
 		end;
 	end;
 end; 

--- a/BGAnimations/ScreenSelectProfile overlay.lua
+++ b/BGAnimations/ScreenSelectProfile overlay.lua
@@ -24,7 +24,7 @@ function GetLocalProfiles()
 			};
 
 			Def.Sprite {
-				InitCommand=cmd(visible,true;halign,0;xy,-98,-2);
+				InitCommand=cmd(visible,true;halign,0;xy,-98,-2;ztest,true;);
 				BeginCommand=cmd(queuecommand,"ModifyAvatar");
 				ModifyAvatarCommand=function(self)
 					self:finishtweening();

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -32,6 +32,7 @@ GhostScoreType=Ghost Scoretype
 GhostTarget=Ghost Target
 ErrorBar=Error Bar
 PaceMaker=Pacemaker Graph
+LaneCover=Lane Cover
 
 DefaultScoreType = Default ScoreType
 TipType = Tip Type
@@ -46,6 +47,7 @@ GhostScoreType= Set Scoretype of ghost score
 GhostTarget= Set target for ghost score
 ErrorBar=Enable Error Bar
 PaceMaker=Enable Pacemaker Graph. The target graph will be the same as your ghostscoretype/target settings.
+LaneCover= Enable lane cover which will cover a portion of the notefield. The height can be adjusted by holding down <Select>+<EffectUp/Down>
 
 DefaultScoreType = Default ScoreType
 TipType = Sets the Tiptype to either display tips or random quotes and phrases or nothing at all.

--- a/Scripts/01 player_config.lua
+++ b/Scripts/01 player_config.lua
@@ -7,6 +7,8 @@ local defaultConfig = {
 	GhostTarget = 1,
 	ErrorBar = false,
 	PaceMaker = false,
+	LaneCover = false,
+	LaneCoverHeight = 0,
 }
 
 playerConfig = create_setting("playerConfig", "playerConfig.lua", defaultConfig, -1)

--- a/Scripts/02 ThemePrefs.lua
+++ b/Scripts/02 ThemePrefs.lua
@@ -229,6 +229,33 @@ function PaceMaker()
 	return t;
 end	
 
+function LaneCover()
+	local t = {
+		Name = "LaneCover";
+		LayoutType = "ShowAllInRow";
+		SelectType = "SelectOne";
+		OneChoiceForAllPlayers = false;
+		ExportOnChange = true;
+		Choices = { THEME:GetString('OptionNames','Off'),'On'};
+		LoadSelections = function(self, list, pn)
+			local pref = playerConfig:get_data(pn_to_profile_slot(pn)).LaneCover
+			if pref then
+				list[2] = true;
+			else
+				list[1] = true;
+			end;
+		end;
+		SaveSelections = function(self, list, pn)
+			local value
+			value = list[2]
+			playerConfig:get_data(pn_to_profile_slot(pn)).LaneCover = value
+			playerConfig:set_dirty(pn_to_profile_slot(pn))
+			playerConfig:save(pn_to_profile_slot(pn))
+		end;
+	};
+	setmetatable( t, t );
+	return t;
+end	
 
 --===============================================
 --Globals

--- a/metrics.ini
+++ b/metrics.ini
@@ -241,7 +241,7 @@ StepsTypeSetCommand=%function(self,param) \
 end; \
 
 [ScreenPlayerOptions]
-LineNames="1,8,14,2,3A,3B,4,5,6,R1,R2,7,9,10,11,12,13,SF,JT,AST,GST,GT,PM,EB,17,16"
+LineNames="1,8,14,2,3A,3B,4,5,6,R1,R2,7,9,10,11,12,13,SF,JT,AST,GST,GT,PM,EB,LC,17,16"
 LineSF="lua,OptionRowScreenFilter()"
 LineJT="lua,JudgeType()"
 LineAST="lua,AvgScoreType()"
@@ -249,6 +249,7 @@ LineGST="lua,GhostScoreType()"
 LineGT="lua,GhostTarget()"
 LinePM="lua,PaceMaker()"
 LineEB="lua,ErrorBar()"
+LineLC="lua,LaneCover()"
 
 [ScreenEvaluation]
 # banner

--- a/metrics.ini
+++ b/metrics.ini
@@ -302,10 +302,20 @@ StreamY=0
 OverX=0
 OverY=0
 
+# Codes on the MusicWheel that change stuff!
+# For Future Reference:
+# @ = Holding
+# - = In Conjuction With / Then
+# ~ = Released
+# + = At The Same Time
 [ScreenGameplay]
-CodeNames="SpeedUp,SpeedDown"
+CodeNames="LaneUp,LaneDown,SpeedUp,SpeedDown,ReleaseUp,ReleaseDown"
 CodeSpeedUp="EffectUp"
 CodeSpeedDown="EffectDown"
+CodeLaneUp="@Select-EffectUp"
+CodeLaneDown="@Select-EffectDown"
+CodeReleaseUp="~EffectUp"
+CodeReleaseDown="~EffectDown"
 
 LifeP1X=50+128
 LifeP1Y=10


### PR DESCRIPTION
Add lane cover for screengameplay

LaneCover can be enabled/disabled in the player options. The height can be adjusted by holding down the Select key and holding EffectUp/EffectDown at the same time to move up/down.
